### PR TITLE
docs: Plan properties can not be overridden

### DIFF
--- a/installing-with-azure.html.md.erb
+++ b/installing-with-azure.html.md.erb
@@ -316,3 +316,34 @@ To remove encryption from the state database:
 1. Click **Apply changes** to install the <%= vars.product_short %> tile.
 
 1. (Recommended) After the apply changes process completes, delete all label and password pairs and apply changes again.
+
+## <a id="plan-defaults"></a> Plan properties can not be overridden
+
+It is important to note that when configuring a service, any plan level properties set can not be overridden when creating a service instance.
+
+For example, if a plan has been defined with the following values: 
+
+    ```json
+    [
+      {
+        "name" : "small",
+        "id" : "UID",
+        "sku_name" : "SKU-NAME",
+        "description" : "A small plan",
+        "location" : "westus",
+        ...
+      }
+    ]
+    ```
+
+If a user tries to provision the service and amend the location with the following command:
+
+<pre>
+cf create-service csb-service small SERVICE-INSTANCE-NAME -c '{"location": "centralus"}'
+</pre>
+
+The service will be successfully provisioned, but the location field will default to the plan property of `westus`, not the supplied parameter of `centralus`. However, properties supplied which are not set at the plan level will be used in the provisioned instance. 
+
+
+
+

--- a/installing-with-azure.html.md.erb
+++ b/installing-with-azure.html.md.erb
@@ -73,15 +73,17 @@ To configure Azure credentials:
 
 1. Click **Save**.
 
-<p class="note">
-  <strong>Note:</strong> You can use different Azure credentials for each service plan.
-  You can set <code>azure_tenant_id</code>, <code>azure_subscription_id</code>,
-  <code>azure_client_secret</code>, and <code>azure_client_id</code> when configuring a service plan
-  in the tile. For more information, see
-  <a href="installing-with-azure.html#services">Configure Services with <%= vars.product_short %></a>.
-  You can also set the credentials as parameters when creating a service using the cf CLI, for example,
-  <code>cf create-service ... -c '{ "azure_subscription_id":"...", ... "'</code>.
-</p>
+<div class="note">
+  <strong>Note:</strong> You can use different Azure credentials for each service plan by setting
+  <code>azure_tenant_id</code>, <code>azure_subscription_id</code>,
+  <code>azure_client_secret</code>, and <code>azure_client_id</code> in one of the following ways:
+  <ul>
+    <li>In the <%= vars.product_short %> tile, set the credentials when configuring a service plan.
+      See <a href="installing-with-azure.html#services">Configure Services with <%= vars.product_short %></a>.</li>
+    <li>In the cf CLI, set the credentials as parameters when creating a service. For example:
+    <pre>cf create-service ... -c '{ "azure_subscription_id":"...", ... "'</pre></li>
+  </ul>
+</div>
 
 ### <a id="state-db"></a>Configure a State Database
 

--- a/installing-with-azure.html.md.erb
+++ b/installing-with-azure.html.md.erb
@@ -74,7 +74,13 @@ To configure Azure credentials:
 1. Click **Save**.
 
 <p class="note">
-  <strong>Note:</strong> It is possible to use different Azure credentials per service plan. `azure_tenant_id`, `azure_subscription_id`, `azure_client_secret`, and `azure_client_id` can be set when [configuring a service plan](installing-with-azure.html#services) in the tile, or given as parameters when creating a service using the cf cli e.g `cf create-service ... -c '{ "azure_subscription_id":"...", ... "'`
+  <strong>Note:</strong> You can use different Azure credentials for each service plan.
+  You can set <code>azure_tenant_id</code>, <code>azure_subscription_id</code>,
+  <code>azure_client_secret</code>, and <code>azure_client_id</code> when configuring a service plan
+  in the tile. For more information, see
+  <a href="installing-with-azure.html#services">Configure Services with <%= vars.product_short %></a>.
+  You can also set the credentials as parameters when creating a service using the cf CLI, for example,
+  <code>cf create-service ... -c '{ "azure_subscription_id":"...", ... "'</code>.
 </p>
 
 ### <a id="state-db"></a>Configure a State Database
@@ -232,6 +238,25 @@ the **Settings** tab.
 For details about properties for each service configuration, see
 <a href="reference.html">Service Plan Reference</a>.
 
+1. (Optional) If you want to use different credentials to the ones specified in the **Azure Config** tab,
+supply the credentials as properties to a plan instance in the additional plans box:
+
+    ```json
+    [
+      {
+        "name" : "PLAN-NAME",
+        "id" : "UID",
+        "sku_name" : "SKU-NAME",
+        "description" : "PLAN-DESCRIPTION",
+        "azure_tenant_id" : "TENANT-ID",
+        "azure_subscription_id" : "SUBSCRIPTION-ID",
+        "azure_client_secret" : "CLIENT-SECRET",
+        "azure_client_id" : "CLIENT-ID",
+        ...
+      }
+    ]
+    ```
+
 1. Click **Save**.
 
 1. Return to the <%= vars.ops_manager %> Installation Dashboard and click **Review Pending Changes**.
@@ -240,24 +265,7 @@ For details about properties for each service configuration, see
 
 1. Review your Cloud Foundry Marketplace to see the new plan sizes.
 
-By default, the newly created plan will use the Azure credentials specified in the `Azure Config` tab. However, different credentials can be supplied as properties to a plan instance when configuring a service. 
 
-<pre>
-[
-  {
-    "name" : "a_small_plan",
-    "id" : "uid",
-    "sku_name" : "sku_name",
-    "description" : "An example plan"
-    "azure_tenant_id" : "value"
-    "azure_subscription_id" : "value"
-    "azure_client_secret" : "value"
-    "azure_client_id" : "value"
-    ...
-  }
-]
-</pre>
-</p>
 
 ## <a id="rotate-password"></a>Rotate the Encryption Password on the State Database
 

--- a/reference.html.md.erb
+++ b/reference.html.md.erb
@@ -515,7 +515,16 @@ No databases are created or managed.
 
 ### <a id="azure-mssql-server-plans"></a> Plans
 
-The only plan is `standard`.
+When configuring the <%= vars.product_short %> you can add additional new plans.
+The table below lists the plan parameters that you can configure:
+
+| Parameter Name    | Values                          | Default   |
+|-------------------|---------------------------------|-----------|
+| name              | The plan name.                  | _n/a_     |
+| id                | A unique GUID.                  | _n/a_     |
+| description       | Description of the new plan.    | _n/a_     |
+
+In addition to these values which must be set, you can add configuration parameters listed in the next section.
 
 ### <a id="azure-mssql-server-parameters"></a> Configuration Parameters
 

--- a/reference.html.md.erb
+++ b/reference.html.md.erb
@@ -20,6 +20,7 @@ See the section below for the service that you want:
 - [Azure PostgreSQL](#azure-postgresql)
 - [Azure CosmosDB](#azure-cosmosdb-sql)
 - [Azure MongoDB](#azure-cosmosdb-mongo)
+- [Azure Redis](#azure-redis)
 - [Azure Storage Account](#azure-storage-account)
 - [Azure Eventhub](#azure-eventhub)
 
@@ -2055,6 +2056,173 @@ The format for binding credentials for Azure Cosmos DB SQL API is as follows:
 {
     "uri" : "The primary master mongodb uri of the Cosmos DB Mongo Collection.",
     "status" : "Status of db"
+}
+```
+
+## <a id="azure-redis"></a> Azure Redis
+
+This section applies to csb-azure-redis.
+This section details the plans and configuration parameters available for Azure Redis.
+
+### <a id="azure-redis-plans"></a> Plans
+
+The table below lists the plans for Azure Redis:
+
+| Plan | Description |
+|------|-------------|
+| small | Basic plan with 1GB cache and no failover. High Availability is not provided, update WILL result in loss of data. |
+| medium | Basic plan with 6GB cache and no failover. High Availability is not provided, update WILL result in loss of data. |
+| large | Basic plan with 26GB cache and no failover. High Availability is not provided, update WILL result in loss of data. |
+| ha-small | Standard plan with 1GB cache with high availability and no failover. |
+| ha-medium | Standard plan with 6GB cache with high availability and no failover. |
+| ha-large | Standard plan with 26GB cache with high availability and no failover. |
+| ha-P1 | A High Availability plan with 1GB cache and no failover |
+
+### <a id="azure-redis-plans-config"></a> Plan Configuration Parameters
+
+When configuring <%= vars.product_short %> you can add additional new plans.
+The table below lists parameters which can only be added at the plan level. Further [configuration properties](#azure-cosmosdb-redis-parameters) can also be supplied as parameters in plan creation.
+
+| Parameter Name    | Description                     | Default   | Example Value |
+|-------------------|---------------------------------|-----------|---------------|
+| name              | The plan name.                  | _n/a_     | "plan_1"      |
+| id                | A unique GUID.                  | _n/a_     | "guid"        |
+| description       | Description of the new plan.    | _n/a_     | "This is a plan" |
+| sku_name | The SKU of Redis to use.  | _n/a_ | "Basic" |
+| family |The SKU family/pricing group to use.  | _n/a_ |  'C' (Basic/Standard)  or  'P' (Premium)|
+| capacity |The size of the Redis cache to deploy. Must be between 1-6 | 1 |  6  |
+| tls_min_version | Minimum enforced TLS version. Possible values are 1.0, 1.1, 1.2 | "1.2" | "1.2" |
+| firewall_rules | Array of firewall rule start/end IP pairs. | []| [["1.2.3.4", "2.3.4.5"], ["5.6.7.8", "6.7.8.9"]] |
+| private_endpoint_subnet_id | The ID of the Subnet within which Private Endpoint for the Redis cache will be created. | ""| "someID" |
+| private_dns_zone_ids | Array of Private DNS Zone IDs to create private DNS zone groups for when using Private Endpoints | [] | ["someID", "anotherID"] |
+
+Further information on plan curation is available in <a href="installing-with-azure.html#services">Configure Services with Cloud Service Broker for Azure</a>.
+
+<p class="note">
+  <strong>Note:</strong> These configuration values set in the plan cannot be changed by the developers during provision or update operations.
+</p>
+
+### <a id="azure-redis-parameters"></a> Configuration Parameters
+
+You can provision a service by running:
+
+```bash
+cf create-service csb-azure-redis PLAN-NAME SERVICE-INSTANCE-NAME -c '{"PARAMETER-NAME": "PARAMETER-VALUE"}'
+```
+
+You can update the configuration parameters for a service instance by running:
+
+```bash
+cf update-service SERVICE-INSTANCE-NAME -c '{"PARAMETER-NAME": "PARAMETER-VALUE"}'
+```
+
+The table below lists the parameters that you can configure, using the `-c` flag, when
+provisioning a csb-azure-redis service:
+
+<table>
+  <thead>
+    <tr>
+      <th width="20%">Parameter Name</th>
+      <th width="10%">Type</th>
+      <th width="40%">Description</th>
+      <th width="10%">Default</th>
+      <th width="20%">Constraints</th>
+    </tr>
+  </thead>
+  <tr>
+    <td><code>instance_name</code></td>
+    <td>string</td>
+    <td>Name for your mysql instance</td>
+    <td><code>csb-redis-INSTANCE-ID</code></td>
+    <td>
+      maxLength: 98
+      minLength: 6
+      pattern: ^[a-z][a-z0-9-]+$
+      **Can not be updated**
+    </td>
+  </tr>
+  <tr>
+    <td><code>resource_group</code></td>
+    <td>string</td>
+    <td>Name for the resource group for this instance</td>
+    <td><code>''</code></td>
+    <td>
+      maxLength: 64
+      minLength: 0
+      pattern: ^[a-z][a-z0-9-]+$|^$
+    </td>
+  </tr>
+  <tr>
+    <td><code>subnet_id</code></td>
+    <td>string</td>
+    <td>The ID of the Subnet within which the Redis Cache should be deployed, valid only for Premium SKU </td>
+    <td><code>''</code></td>
+    <td>
+    **Can not be updated**
+    </td>
+  </tr>
+  <tr>
+    <td><code>location</code></td>
+    <td>string</td>
+    <td>The location of the Redis instance.</td>
+    <td><code>westus</code></td>
+    <td>See locations [here](https://azure.microsoft.com/en-gb/global-infrastructure/data-residency/#select-geography)
+    </td>
+  </tr>
+ <tr>
+    <td><code>azure_tenant_id</code></td>
+    <td>string</td>
+    <td>Azure Tenant to create resource in</td>
+    <td>Value set in `Azure Config` tab</td>
+    <td>n/a</td>
+  </tr>
+  <tr>
+    <td><code>azure_subscription_id</code></td>
+    <td>string</td>
+    <td>Azure Subscription to create resource in</td>
+    <td>Value set in `Azure Config` tab</td>
+    <td>n/a</td>
+  </tr>
+  <tr>
+    <td><code>azure_client_id</code></td>
+    <td>string</td>
+    <td> Client ID of Azure principal</td>
+    <td>Value set in `Azure Config` tab</td>
+    <td>n/a</td>
+  </tr>
+  <tr>
+    <td><code>azure_client_secret</code></td>
+    <td>string</td>
+    <td>Client secret for Azure principal</td>
+    <td>Value set in `Azure Config` tab</td>
+    <td>n/a</td>
+  </tr>
+  <tr>
+    <td><code>skip_provider_registration</code></td>
+    <td>boolean</td>
+    <td>Skip automatic Azure provider registration, set to true if service principal being used does not have rights to register providers</td>
+    <td>false</td>
+    <td>n/a</td>
+  </tr>
+  <tr>
+    <td><code>maxmemory_policy</code></td>
+    <td>string</td>
+    <td>Max memory eviction policy.</td>
+    <td><code>volatile-lru</code></td>
+    <td>Possible values are <code>volatile-lru</code>, <code>allkeys-lru</code>, <code>volatile-random</code>, <code>allkeys-random</code>, <code>volatile-ttl</code>, <code>noeviction</code></td>
+  </tr>
+</table>
+
+### <a id="azure-redis-binding-creds"></a> Binding Credentials
+
+The format for binding credentials for Azure Redis is as follows:
+
+```json
+{
+    "name" : "The name of the redis.",
+    "host" : "Hostname or IP address of the exposed redis endpoint used by clients to connect to the service.",
+    "tls_port" : "The tls_port number of the exposed redis instance.",
+    "password" : "The password to authenticate to the redis instance."
 }
 ```
 

--- a/reference.html.md.erb
+++ b/reference.html.md.erb
@@ -515,6 +515,8 @@ No databases are created or managed.
 
 ### <a id="azure-mssql-server-plans"></a> Plans
 
+The only plan available pre-configured is `standard`
+
 When configuring the <%= vars.product_short %> you can add additional new plans.
 The table below lists the plan parameters that you can configure:
 
@@ -2365,11 +2367,16 @@ This section details the plans and configuration parameters available for Azure 
 
 ### <a id="azure-resource-group-plans"></a> Plans
 
-The table below lists the plans for Azure Storage Account:
+The only plan available by default when the tile is installed is `standard`. 
 
-| Plan | Description |
-|------|-------------|
-| standard | An Azure Resource Group |
+When configuring the <%= vars.product_short %> you can add additional new plans.
+The table below lists the plan parameters that you can configure:
+
+| Parameter Name    | Values                          | Default   |
+|-------------------|---------------------------------|-----------|
+| name              | The plan name.                  | _n/a_     |
+| id                | A unique GUID.                  | _n/a_     |
+| description       | Description of the new plan.    | _n/a_     |
 
 ### <a id="azure-resource-group-parameters"></a> Configuration Parameters
 


### PR DESCRIPTION
Hi Docs 👋

We'd appreciate your guidance on this one. This is an important point for tile operators to consider, and we want to ensure that the warning is visible. 

As you can see in the PR, any values specified in a plan configuration can't be overridden when a user attempts to create a service with the `cf cli`. 

We're not sure how much of an issue this will actually be for users, and potentially having this inclusion in the docs is enough, but you may feel a note is necessary on the `plan references` page. 

Happy to chat this one through on slack/zoom 

Many thanks

James 