### PR TITLE
chore: highlight not to leave instances on subsume plan

### DIFF
--- a/azure-mssql-fog-subsume.html.md.erb
+++ b/azure-mssql-fog-subsume.html.md.erb
@@ -273,7 +273,7 @@ configuration of the plan that the MAS-brokered instance used by running:
     cf update-service NEW-SERVICE-INSTANCE -p PLAN-NAME
     ```
 
-    Where `PLAN-NAME` is the name of the plan. You can use one of the default plans or a custom plan.
+    Where `PLAN-NAME` is the name of the plan. You can use one of the default plans or a custom plan. Instances must be updated to a plan other than `subsume` in order to be managable by the <%= vars.product_short %>.
 
     <p class="note">
       <strong> Note:</strong> Changing the plan updates the service instance to

--- a/azure-mssql-subsume.html.md.erb
+++ b/azure-mssql-subsume.html.md.erb
@@ -233,7 +233,7 @@ configuration of the plan that the MAS-brokered instance used by running:
     cf update-service NEW-SERVICE-INSTANCE -p PLAN-NAME
     ```
 
-    Where `PLAN-NAME` is the name of the plan. You can use one of the default plans or a custom plan.
+    Where `PLAN-NAME` is the name of the plan. You can use one of the default plans or a custom plan. Instances must be updated to a plan other than `subsume` in order to be managable by the <%= vars.product_short %>.
 
     <p class="note">
       <strong> Note:</strong> Changing the plan updates the service instance to


### PR DESCRIPTION
Hi wonderful Docs team 👋 

This is just a small note reminding users to migrate their plan off of `subsume`, once they have subsumed an instance. 

Please can this be cherry picked to 1.2 && 1.1

[#182592988](https://www.pivotaltracker.com/story/show/182592988)

