### PR TITLE
fix: removed step that doesn't make sense

### DIFF
--- a/installing-with-azure.html.md.erb
+++ b/installing-with-azure.html.md.erb
@@ -143,8 +143,6 @@ To configure <%= vars.product_short %> with a state database:
 
 1. Click **Apply changes** to install the <%= vars.product_short %> tile.
 
-1. Set up encryption for the sensitive data in the database.
-
 If you later want to change the password on the state database,
 see [Rotate the Encryption Password on the State Database](#rotate-password) below.<br>
 If you later want to turn off encryption,


### PR DESCRIPTION
It looks like this text was previously a title. It doesn't appear in the
equivalent text on AWS or GCP

[#181523458](https://www.pivotaltracker.com/story/show/181523458)

Which other branches should this be merged with (if any)?
- 1.2
