### PR TITLE
fix: service images now display in apps manager

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -24,8 +24,7 @@ New features and changes in this release:
 
 This release has the following fixes:
 
-* **RUN-IN HEADING:** DESCRIPTION
-* **RUN-IN HEADING:** DESCRIPTION
+* **Apps Manager Service images:** The service image logo now displays in Apps Manager, or other GUI applications.
 
 
 ### Known Issues


### PR DESCRIPTION
Hi Docs 👋 

Just a small fix in the upcoming release, previously the logos didn't display in Apps Manager, now they do!

[#183058257](https://www.pivotaltracker.com/story/show/183058257)


