### PR TITLE
fix typo in config key name

### DIFF
--- a/installing-with-azure.html.md.erb
+++ b/installing-with-azure.html.md.erb
@@ -196,7 +196,7 @@ the **Settings** tab.
        "SERVER-LABEL":{
           "admin_username": "SERVER-ADMIN-USERNAME",
           "admin_password": "SERVER-ADMIN-PASSWORD",
-          "resource_group": "SERVER-RESOURCE-GROUP",
+          "server_resource_group": "SERVER-RESOURCE-GROUP",
           "server_name": "SERVER-NAME"
        }
        ...


### PR DESCRIPTION
For csb-azure-mssql-db the resource group config key is `server_resource_group` which differs from what is needed for other services.

Which other branches should this be merged with (if any)?
- 1.4
- 1.3
- 1.2
