### PR TITLE
consistency of default values

### DIFF
--- a/reference/azure-cosmosdb-mongo.html.md.erb
+++ b/reference/azure-cosmosdb-mongo.html.md.erb
@@ -184,7 +184,7 @@ provisioning a csb-azure-mongodb service:
       <code>0.0.0.0</code> allows access from Azure networks.
       An empty string <code>""</code> allows access from all public networks.
     </td>
-    <td><code>"0.0.0.0"</code></td>
+    <td><code>0.0.0.0</code></td>
     <td>provision and update</td>
   </tr>
   <tr>

--- a/reference/azure-cosmosdb-sql.html.md.erb
+++ b/reference/azure-cosmosdb-sql.html.md.erb
@@ -90,14 +90,14 @@ provisioning a csb-azure-cosmosdb-sql service:
       For available locations, see the
       <a href="https://azure.microsoft.com/en-gb/global-infrastructure/data-residency/#select-geography">Microsoft documentation</a>.
     </td>
-    <td><code>westus</code></td>
+    <td><code>["westus"]</code></td>
     <td>provision and update</td>
   </tr>
   <tr>
     <td><code>instance_name</code></td>
     <td>string</td>
     <td>The instance name for your Cosmos DB.</td>
-    <td><code>csb-INSTANCE-ID</code></td>
+    <td><code>csbINSTANCE-ID</code></td>
     <td>provision and update</td>
   </tr>
   <tr>
@@ -111,7 +111,7 @@ provisioning a csb-azure-cosmosdb-sql service:
     <td><code>db_name</code></td>
     <td>string</td>
     <td>The name for your Cosmos DB database.</td>
-    <td><code>csb-db-INSTANCE-ID</code></td>
+    <td><code>csb-dbINSTANCE-ID</code></td>
     <td>provision and update</td>
   </tr>
   <tr>
@@ -241,7 +241,7 @@ provisioning a csb-azure-cosmosdb-sql service:
   </tr>
   <tr>
     <td><code>private_dns_zone_ids</code></td>
-    <td>list (string)</td>
+    <td>array</td>
     <td>A list of private DNS Zone IDs to create private DNS zone groups for when using private endpoints.</td>
     <td><code>[]</code></td>
     <td>provision and update</td>

--- a/reference/azure-mssql-db.html.md.erb
+++ b/reference/azure-mssql-db.html.md.erb
@@ -129,7 +129,7 @@ provisioning or updating a csb-azure-mssql-db service:
       (Required) The name of the server on which to create the database.
       This must match one of the <code>SERVER</code> parameters in one of the servers configured when configuring the service.
     </td>
-    <td><em>n/a</em></td>
+    <td>None</td>
     <td>provision and update</td>
   </tr>
   <tr>
@@ -164,14 +164,14 @@ provisioning or updating a csb-azure-mssql-db service:
     <td><code>cores</code></td>
     <td>number</td>
     <td>Number vCores for the instance (up to the maximum allowed for the service tier). 1&ndash;80, multiples of 2 </td>
-    <td> 2 </td>
+    <td><code>2</code></td>
     <td>provision and update</td>
   </tr>
   <tr>
     <td><code>max_storage_gb</code></td>
     <td>number</td>
     <td>Maximum storage allocated to the database instance in GB.</td>
-    <td> 5 </td>
+    <td><code>5</code></td>
     <td>provision and update</td>
   </tr>
   <tr>

--- a/reference/azure-mssql-fog-preconfig.html.md.erb
+++ b/reference/azure-mssql-fog-preconfig.html.md.erb
@@ -99,7 +99,7 @@ provisioning a csb-azure-mssql-db-failover-group service:
     <td>
       This must match one of the <code>server_credential_pairs</code> parameters in one of the servers configured when configuring the service.
     </td>
-    <td><em>n/a</em></td>
+    <td>None</td>
     <td>provision and update</td>
   </tr>
   <tr>
@@ -148,14 +148,14 @@ provisioning a csb-azure-mssql-db-failover-group service:
     <td><code>cores</code></td>
     <td>number</td>
     <td>Number of vCores for the instance (up to the maximum allowed for the service tier). 1&ndash;80, multiples of 2 </td>
-    <td> 2 </td>
+    <td><code>2</code></td>
     <td>provision and update</td>
   </tr>
   <tr>
     <td><code>max_storage_gb</code></td>
     <td>number</td>
     <td>Maximum storage allocated to the database instance in GB.</td>
-    <td> 5 </td>
+    <td><code>5</code></td>
     <td>provision and update</td>
   </tr>
   <tr>

--- a/reference/azure-mssql-fog-runner.html.md.erb
+++ b/reference/azure-mssql-fog-runner.html.md.erb
@@ -53,7 +53,7 @@ provisioning a csb-azure-mssql-fog-run-failover service:
     <td><code>fog_instance_name</code>*</td>
     <td>string</td>
     <td>(Required) The name of the service instance for the failover group to target.</td>
-    <td><em>n/a</em></td>
+    <td>None</td>
     <td>provision and update</td>
   </tr>
   <tr>
@@ -64,7 +64,7 @@ provisioning a csb-azure-mssql-fog-run-failover service:
       This must match one of the <code>PAIR</code> parameters in <code>server_pairs</code>.
       For example, <code>PAIR-1</code> in the code snippet in the <code>server_credentials_pairs</code> row below.
     </td>
-    <td><em>n/a</em></td>
+    <td>None</td>
     <td>provision and update</td>
   </tr>
   <tr>
@@ -75,7 +75,7 @@ provisioning a csb-azure-mssql-fog-run-failover service:
       Format: <pre><code>{ "PAIR-1": { "primary":{"server_name":"...", "resource_group":..."}, "secondary":{"server_name":"...", "resource_group":..."}, "PAIR-2":...}</code></pre>
       One of the values you use for <code>PAIR</code> must match the <code>server_pair_name</code> parameter above.
     </td>
-    <td><em>n/a</em></td>
+    <td>None</td>
     <td>provision and update</td>
   </tr>
   <tr>

--- a/reference/azure-mssql-fog.html.md.erb
+++ b/reference/azure-mssql-fog.html.md.erb
@@ -65,7 +65,7 @@ provisioning a csb-azure-mssql-failover-group service:
     <td><code>instance_name</code></td>
     <td>string</td>
     <td>The name of the service instance.</td>
-    <td><code>csb-azsql-INSTANCE-ID</code></td>
+    <td><code>csb-azsql-fog-INSTANCE-ID</code></td>
     <td>provision</td>
   </tr>
   <tr>
@@ -99,7 +99,7 @@ provisioning a csb-azure-mssql-failover-group service:
     <td><code>failover_location</code></td>
     <td>string</td>
     <td>The Azure region for the failover instance.</td>
-    <td><code>DEFAULT-REGIONAL-PAIR</code>. For information about regional pairs, see the <a href="https://docs.microsoft.com/en-us/azure/best-practices-availability-paired-regions#azure-regional-pairs">Microsoft Documentation</a></td>
+    <td><code>default</code>. For information about regional pairs, see the <a href="https://docs.microsoft.com/en-us/azure/best-practices-availability-paired-regions#azure-regional-pairs">Microsoft Documentation</a></td>
     <td>provision and update</td>
   </tr>
   <tr>
@@ -165,14 +165,14 @@ provisioning a csb-azure-mssql-failover-group service:
     <td><code>cores</code></td>
     <td>number</td>
     <td>Number of vCores for the instance (up to the maximum allowed for the service tier). 1&ndash;80, multiples of 2 </td>
-    <td> 2 </td>
+    <td><code>2</code></td>
     <td>provision and update</td>
   </tr>
   <tr>
     <td><code>max_storage_gb</code></td>
     <td>number</td>
     <td>Maximum storage allocated to the database instance in GB.</td>
-    <td> 5 </td>
+    <td><code>5</code></td>
     <td>provision and update</td>
   </tr>
   <tr>
@@ -190,7 +190,7 @@ provisioning a csb-azure-mssql-failover-group service:
     <td>string</td>
     <td>The Azure subnet ID, in long form, that the instance is connected to through a service endpoint.
     The subnet must have the <code>Microsoft.sql</code> service enabled.</td>
-    <td><em>n/a</em></td>
+    <td><code>default</code></td>
     <td>provision and update</td>
   </tr>
   <tr>

--- a/reference/azure-mssql.html.md.erb
+++ b/reference/azure-mssql.html.md.erb
@@ -153,14 +153,14 @@ main table {
     <td><code>cores</code></td>
     <td>number</td>
     <td>Number of vCores for the instance (up to the maximum allowed for the service tier). 1&ndash;80, multiples of 2 </td>
-    <td> 2 </td>
+    <td><code>2</code></td>
     <td>provision and update</td>
   </tr>
   <tr>
     <td><code>max_storage_gb</code></td>
     <td>number</td>
     <td>Maximum storage allocated to the database instance in GB.</td>
-    <td> 5 </td>
+    <td><code>5</code></td>
     <td>provision and update</td>
   </tr>
   <tr>
@@ -178,7 +178,7 @@ main table {
     <td>string</td>
     <td>The Azure subnet ID, in long form, that the instance is connected to through a service endpoint.
     The subnet must have the <code>Microsoft.sql</code> service enabled.</td>
-    <td><em>n/a</em></td>
+    <td><code>default</code></td>
     <td>provision and update</td>
   </tr>
   <tr>

--- a/reference/azure-mysql.html.md.erb
+++ b/reference/azure-mysql.html.md.erb
@@ -120,7 +120,7 @@ provisioning or updating a csb-azure-mysql service:
       The version for the MySQL instance. After being set, this cannot be updated. <br>
       The available versions are: <code>"5.6"</code>, <code>"5.7"</code>, and <code>"8.0"</code>.
     </td>
-    <td><code>"5.7"</code></td>
+    <td><code>5.7</code></td>
     <td>provision</td>
   </tr>
   <tr>
@@ -170,7 +170,7 @@ provisioning or updating a csb-azure-mysql service:
     <td><code>authorized_networks</code></td>
     <td>array</td>
     <td>The subnet IDs of the Azure Virtual Network (VNet) that is attached to this instance.</td>
-    <td><code>default</code></td>
+    <td><code>[]</code></td>
     <td>provision and update</td>
   </tr>
   <tr>

--- a/reference/azure-postgresql.html.md.erb
+++ b/reference/azure-postgresql.html.md.erb
@@ -74,7 +74,7 @@ provisioning a csb-azure-postgresql service:
     <td><code>instance_name</code></td>
     <td>string</td>
     <td>The name of the Azure instance to create.</td>
-    <td><code>csb-mysql-INSTANCE-ID</code></td>
+    <td><code>csb-postgresql-INSTANCE-ID</code></td>
     <td>provision</td>
   </tr>
   <tr>
@@ -133,21 +133,21 @@ provisioning a csb-azure-postgresql service:
       that is attached to this instance to allow remote access.
       By default no VNets are allowed access.
     </td>
-    <td><em>n/a</em></td>
+    <td><code>default</code></td>
     <td>provision and update</td>
   </tr>
     <tr>
     <td><code>cores</code></td>
     <td>integer</td>
     <td>Number of vCores for the instance (up to the maximum allowed for the service tier). 1&ndash;64, multiples of 2 </td>
-    <td> 2 </td>
+    <td><code>2</code></td>
     <td>provision and update</td>
   </tr>
   <tr>
     <td><code>storage_gb</code></td>
     <td>number</td>
     <td>Maximum storage allocated to the database instance in GB. 5&ndash;4096</td>
-    <td> 5 </td>
+    <td><code>5</code></td>
     <td>provision and update</td>
   </tr>
   <tr>

--- a/reference/azure-redis.html.md.erb
+++ b/reference/azure-redis.html.md.erb
@@ -104,7 +104,7 @@ provisioning a csb-azure-redis service:
     <td>
       The version of Redis to use. If not set, the default Azure-defined Redis version is used.
     </td>
-    <td><code>""</code></td>
+    <td>None</td>
     <td>provision and update</td>
   </tr>
   <tr>
@@ -125,7 +125,7 @@ provisioning a csb-azure-redis service:
     <td><code>subnet_id</code></td>
     <td>string</td>
     <td>The ID of the Subnet within which the Redis Cache should be deployed. Valid only for Premium SKU. After being set, this cannot be updated.</td>
-    <td><code>''</code></td>
+    <td><code>""</code></td>
     <td>provision</td>
   </tr>
   <tr>

--- a/reference/azure-resource-group.html.md.erb
+++ b/reference/azure-resource-group.html.md.erb
@@ -70,7 +70,7 @@ provisioning a csb-azure-resource-group service:
     <td><code>instance_name</code></td>
     <td>string</td>
     <td>(Required) The name of the Azure Resource Group.</td>
-    <td><em>n/a</em></td>
+    <td>None</td>
     <td>provision and update</td>
   </tr>
   <tr>

--- a/reference/azure-storage-account.html.md.erb
+++ b/reference/azure-storage-account.html.md.erb
@@ -144,7 +144,7 @@ provisioning a csb-azure-storage-account service:
   </tr>
   <tr>
     <td><code>authorized_networks</code></td>
-    <td>list (string)</td>
+    <td>array</td>
     <td>A list of resource IDs for subnets of the authorized Azure Vnet.</td>
     <td><code>[]</code></td>
     <td>provision and update</td>


### PR DESCRIPTION
- if enclosed in <code>, the value should exactly match the brokerpak spec
- when no default exists, `None` should be used rather than N/A
- where the default is badly formatted (csbINSTANCE-ID for instance) the docs should show the value that matches the brokerpak spec, rather than what we thing the brokerpak spec should have been

[#184710879](https://www.pivotaltracker.com/story/show/184710879)

Which other branches should this be merged with (if any)?
- 1.4
- 1.3
